### PR TITLE
Namespace registered Faraday middleware

### DIFF
--- a/lib/diffbot/api_client.rb
+++ b/lib/diffbot/api_client.rb
@@ -69,7 +69,7 @@ module Diffbot
         # Handle error responses
         faraday.response :raise_error
         # Parse JSON response bodies
-        faraday.response :parse_json
+        faraday.response :diffbot_parse_json
         # Set default HTTP adapter
         faraday.adapter :net_http
       end

--- a/lib/diffbot/api_client/faraday.rb
+++ b/lib/diffbot/api_client/faraday.rb
@@ -27,4 +27,4 @@ module Diffbot
   end
 end
 
-Faraday::Response.register_middleware :parse_json => Diffbot::APIClient::FaradayMiddleware::ParseJson
+Faraday::Response.register_middleware :diffbot_parse_json => Diffbot::APIClient::FaradayMiddleware::ParseJson


### PR DESCRIPTION
Just namespacing the code for a middleware in a module is, sadly, not enough, as the name when you register it might clash with middleware from other libraries that register the same type of middleware (for example, the [Twitter ruby gem](https://github.com/sferik/twitter) registers a `:parse_json` middleware, which provokes projects using both the twitter and diffbot gems to raise an error when an error response comes back from twitter.
