### PR TITLE
Fix that timeouts try to raise an undefined exception class.

### DIFF
--- a/lib/diffbot/api_client.rb
+++ b/lib/diffbot/api_client.rb
@@ -188,7 +188,7 @@ module Diffbot
       end
       response.env
     rescue Faraday::Error::TimeoutError, Timeout::Error => error
-      raise(Diffbot::APIClient::Error::RequestTimeout.new(error))
+      raise(Diffbot::APIClient::RequestTimeout.new(error))
     rescue Faraday::Error::ClientError, JSON::ParserError => error
       fail(Diffbot::APIClient::Error.new(error))
     end

--- a/spec/api_client_spec.rb
+++ b/spec/api_client_spec.rb
@@ -32,5 +32,22 @@ describe Diffbot::APIClient do
       response.should be_a(Hash)
       response[:url].should eq("http://diffbot.com")
     end
+
+    context "when the request times out" do
+      let(:faraday) { double("Faraday") }
+
+      before(:each) do
+        allow(Faraday).to receive(:new).and_return(faraday)
+        allow(faraday).to receive(:get).and_raise(Faraday::Error::TimeoutError)
+      end
+
+      it "raises a Diffbot::APIClient::RequestTimeout error" do
+        client = Diffbot::APIClient.new(token: DEVELOPER_TOKEN)
+        expect do
+          client.get "v2/analyze",
+                     token: client.token, url: "http://diffbot.com"
+        end.to raise_error(Diffbot::APIClient::RequestTimeout)
+      end
+    end
   end
 end


### PR DESCRIPTION
If a timeout happens, `APIClient` currently tries to raise a `Diffbot::APIClient::Error::RequestTimeout` exception, which is undefined. The class is actually `Diffbot::APIClient::RequestTimeout`.