### PR TITLE
Handle 401 errors from Diffbot.

### DIFF
--- a/lib/diffbot/api_client.rb
+++ b/lib/diffbot/api_client.rb
@@ -186,6 +186,10 @@ module Diffbot
       response = connection.send(method.to_sym, path, data) do |request|
         request.headers.update(headers)
       end
+
+      code = response.env[:body][:errorCode]
+      raise(Diffbot::APIClient::Unauthorized.new(code)) if code == 401
+
       response.env
     rescue Faraday::Error::TimeoutError, Timeout::Error => error
       raise(Diffbot::APIClient::RequestTimeout.new(error))

--- a/lib/diffbot/api_client/bot.rb
+++ b/lib/diffbot/api_client/bot.rb
@@ -9,9 +9,9 @@ module Diffbot
       # @param options [Hash]
       def initialize client, options = {}
         @api = options.delete(:api)
-        raise ArgumentError.new("client should be an instance of Diffbot::APIClient::GenericAPI") unless @api.is_a?(Diffbot::APIClient::GenericAPI)
+        raise ArgumentError.new("client should be an instance of Diffbot::APIClient::GenericAPI") unless @api.nil? || @api.is_a?(Diffbot::APIClient::GenericAPI)
 
-        options[:apiUrl] = @api.full_url
+        options[:apiUrl] = @api.full_url if @api
 
         raise ArgumentError.new("client should be an instance of Diffbot::APIClient") unless client.is_a?(Diffbot::APIClient)
         @client = client
@@ -33,6 +33,7 @@ module Diffbot
       #
       # @return [Hash]
       def details
+        return @details if @details
         post
       end
 

--- a/lib/diffbot/api_client/bulk.rb
+++ b/lib/diffbot/api_client/bulk.rb
@@ -11,7 +11,7 @@ module Diffbot
       def initialize client, options = {}
         super(client, options)
 
-        post(parse_params(options))
+        @details = post(parse_params(options))
       end
 
       # Return request path

--- a/lib/diffbot/api_client/error.rb
+++ b/lib/diffbot/api_client/error.rb
@@ -24,5 +24,8 @@ module Diffbot
     class RequestTimeout < Error
     end
 
+    # Raised when Diffbot returns errorCode 401.
+    class Unauthorized < Error
+    end
   end
 end


### PR DESCRIPTION
I've added basic error handling for when Diffbot returns a 401.  This change makes it throw an actual exception so the calling code doesn't have to check for a success response on every request.